### PR TITLE
update for container vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet build
 RUN dotnet publish --runtime alpine-x64 -c Release -o out --self-contained true /p:PublishTrimmed=true
 
 # build runtime image with DoD CA Certificates
-FROM cingulara/openrmf-base:1.04.00
+FROM cingulara/openrmf-base:1.08.02
 RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
 RUN mkdir /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.01
+VERSION ?= 1.08.02
 NAME ?= "openrmf-api-audit"
 AUTHOR ?= "Dale Bingham"
 PORT_EXT ?= 8096

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.00
+VERSION ?= 1.08.01
 NAME ?= "openrmf-api-audit"
 AUTHOR ?= "Dale Bingham"
 PORT_EXT ?= 8096

--- a/src/openrmf-api-audit.csproj
+++ b/src/openrmf-api-audit.csproj
@@ -23,11 +23,17 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="mongodb.driver" Version="2.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.5.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Commits on Aug 28, 2022
[update to latest base image](https://github.com/Cingulara/openrmf-api-audit/commit/2ac044bda89babdd55e9233aa3a5a08684b7b529)

Commits on Nov 27, 2022
[updating vulnerability information for v1.8.3](https://github.com/Cingulara/openrmf-api-audit/commit/18ffb6223244b9fb337d3fe9d2592c04adeea677)